### PR TITLE
Use toshi-types, update to tantivy 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ path = "src-rust/main.rs"
 tantivy = { git = "https://github.com/tantivy-search/tantivy.git", rev = "7e08e0047bf842d2ce0f9cd7791451bffb85e2f6" }
 serde_json = { version = "^1.0", features = ["preserve_order"] }
 serde = { version = "^1.0", features = ["derive"] }
-toshi-query = { git = "https://github.com/arso-project/Toshi.git", branch = "toshi-query-tantivymaster" }
+toshi-types = { path = "../Toshi/toshi-types" }
 log = "^0.4"
 uuid = "^0.7"
 failure = "^0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ name = "sonar-tantivy"
 path = "src-rust/main.rs"
 
 [dependencies]
-tantivy = { git = "https://github.com/tantivy-search/tantivy.git", rev = "7e08e0047bf842d2ce0f9cd7791451bffb85e2f6" }
+tantivy = "^0.11"
 serde_json = { version = "^1.0", features = ["preserve_order"] }
 serde = { version = "^1.0", features = ["derive"] }
-toshi-types = { path = "../Toshi/toshi-types" }
+toshi-types = { git = "https://github.com/arso-project/Toshi.git", rev = "tantivy-0.11" }
 log = "^0.4"
 uuid = "^0.7"
 failure = "^0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ path = "src-rust/main.rs"
 tantivy = "^0.11"
 serde_json = { version = "^1.0", features = ["preserve_order"] }
 serde = { version = "^1.0", features = ["derive"] }
-toshi-types = { git = "https://github.com/arso-project/Toshi.git", rev = "tantivy-0.11" }
+toshi-types = { git = "https://github.com/arso-project/Toshi.git", branch = "tantivy-0.11" }
 log = "^0.4"
 uuid = "^0.7"
 failure = "^0.1"

--- a/src-rust/index.rs
+++ b/src-rust/index.rs
@@ -46,7 +46,6 @@ impl IndexCatalog {
         fs::create_dir_all(&base_path)
     }
 
-
     fn load_all(&mut self) {
         //let mut index_paths = vec![];
         if let Ok(entries) = fs::read_dir(&self.base_path) {
@@ -86,14 +85,14 @@ impl IndexCatalog {
             )
         }
     }
-    
-    fn get_indexpath(&mut self, name : &str) -> PathBuf{
+
+    fn get_indexpath(&mut self, name: &str) -> PathBuf {
         let mut index_path = self.base_path.clone();
         index_path.push(&name);
         index_path
     }
-    
-    pub fn delete_index(&mut self, name:String) -> Result<()> {
+
+    pub fn delete_index(&mut self, name: String) -> Result<()> {
         let index_path = self.get_indexpath(&name);
         fs::remove_dir_all(&index_path);
         self.indexes.remove(&name);
@@ -230,7 +229,7 @@ impl IndexHandle {
         if self.query_parser.is_none() {
             let mut fields = vec![];
             let all_fields = schema.fields();
-            for field_entry in all_fields {
+            for (_field, field_entry) in all_fields {
                 if !field_entry.is_indexed() {
                     break;
                 }

--- a/src-rust/main.rs
+++ b/src-rust/main.rs
@@ -1,4 +1,6 @@
 extern crate failure;
+#[macro_use]
+extern crate log;
 use crate::index::IndexCatalog;
 use rpc::Rpc;
 use std::env;

--- a/src-rust/query.rs
+++ b/src-rust/query.rs
@@ -103,8 +103,7 @@ fn search_index(index: &Index, searcher: &Searcher, search: Search) -> ToshiResu
             Query::Raw { raw } => {
                 let fields: Vec<Field> = schema
                     .fields()
-                    .iter()
-                    .filter_map(|e| schema.get_field(e.name()))
+                    .filter_map(|(_, e)| schema.get_field(e.name()))
                     .collect();
                 let query_parser = QueryParser::for_index(index, fields);
                 let query = query_parser.parse_query(&raw)?;

--- a/src-rust/query.rs
+++ b/src-rust/query.rs
@@ -4,8 +4,20 @@ use crate::rpc::Request;
 use failure::Error;
 use serde::Deserialize;
 use serde_json::Value;
-use toshi_query::search::search_index;
-use toshi_query::{Search, SearchResults};
+use std::collections::BTreeMap;
+
+use tantivy::query::{AllQuery, QueryParser};
+use tantivy::schema::{Field, Value as TantivyValue};
+use tantivy::{Index, Searcher};
+
+use toshi_types::client::ScoredDoc;
+use toshi_types::client::SearchResults as SD;
+use toshi_types::error::Error as ToshiError;
+use toshi_types::query::Search;
+use toshi_types::query::*;
+
+type SearchResults = SD<BTreeMap<String, Vec<TantivyValue>>>;
+type ToshiResult<T> = std::result::Result<T, toshi_types::error::Error>;
 
 #[derive(Deserialize)]
 struct QueryRequest {
@@ -33,5 +45,96 @@ pub fn query_json(catalog: &mut IndexCatalog, request: &Request) -> Result<Res, 
             Ok(Res::Json(string))
         }
         Err(err) => Err(err.into()),
+    }
+}
+
+use tantivy::collector::{FacetCollector, MultiCollector, TopDocs};
+
+fn search_index(index: &Index, searcher: &Searcher, search: Search) -> ToshiResult<SearchResults> {
+    let schema = index.schema();
+    let collector = TopDocs::with_limit(search.limit);
+    let mut multi_collector = MultiCollector::new();
+
+    let top_handle = multi_collector.add_collector(collector);
+    let facet_handle = search.facets.clone().and_then(|f| {
+        if let Some(field) = schema.get_field(&f.get_facets_fields()) {
+            let mut col = FacetCollector::for_field(field);
+            for term in f.get_facets_values() {
+                col.add_facet(&term);
+            }
+            Some(multi_collector.add_collector(col))
+        } else {
+            None
+        }
+    });
+
+    if let Some(query) = search.query {
+        let mut scored_docs = match query {
+            Query::Regex(regex) => {
+                let regex_query = regex.create_query(&schema)?;
+                debug!("{:?}", regex_query);
+                searcher.search(&*regex_query, &multi_collector)?
+            }
+            Query::Phrase(phrase) => {
+                let phrase_query = phrase.create_query(&schema)?;
+                debug!("{:?}", phrase_query);
+                searcher.search(&*phrase_query, &multi_collector)?
+            }
+            Query::Fuzzy(fuzzy) => {
+                let fuzzy_query = fuzzy.create_query(&schema)?;
+                debug!("{:?}", fuzzy_query);
+                searcher.search(&*fuzzy_query, &multi_collector)?
+            }
+            Query::Exact(term) => {
+                let exact_query = term.create_query(&schema)?;
+                debug!("{:?}", exact_query);
+                searcher.search(&*exact_query, &multi_collector)?
+            }
+            Query::Boolean { bool } => {
+                let bool_query = bool.create_query(&schema)?;
+                debug!("{:?}", bool_query);
+                searcher.search(&*bool_query, &multi_collector)?
+            }
+            Query::Range(range) => {
+                let range_query = range.create_query(&schema)?;
+                debug!("{:?}", range_query);
+                searcher.search(&*range_query, &multi_collector)?
+            }
+            Query::Raw { raw } => {
+                let fields: Vec<Field> = schema
+                    .fields()
+                    .iter()
+                    .filter_map(|e| schema.get_field(e.name()))
+                    .collect();
+                let query_parser = QueryParser::for_index(index, fields);
+                let query = query_parser.parse_query(&raw)?;
+                debug!("{:?}", query);
+                searcher.search(&*query, &multi_collector)?
+            }
+            Query::All => searcher.search(&AllQuery, &multi_collector)?,
+        };
+
+        let docs: Vec<ScoredDoc<BTreeMap<_, _>>> = top_handle
+            .extract(&mut scored_docs)
+            .into_iter()
+            .map(|(score, doc)| {
+                let d = searcher.doc(doc).expect("Doc not found in segment");
+                ScoredDoc::<BTreeMap<_, _>>::new(Some(score), schema.to_named_doc(&d).0)
+            })
+            .collect();
+
+        if let Some(facets) = facet_handle {
+            if let Some(t) = &search.facets {
+                let facet_counts = facets
+                    .extract(&mut scored_docs)
+                    .get(&t.get_facets_values()[0])
+                    .map(|(f, c)| KeyValue::new(f.to_string(), c))
+                    .collect();
+                return Ok(SearchResults::with_facets(docs, facet_counts));
+            }
+        }
+        Ok(SearchResults::new(docs))
+    } else {
+        Err(ToshiError::QueryError("Empty Query Provided".into()))
     }
 }


### PR DESCRIPTION
Tantivy v0.11 was released, so we can finally leave the git dependency for now!
Two little fixes were needed, not much at all.

And then the toshi-types crate is there now. It included all types we need to use the queries. The main search function however is not in toshi-types. I copied that one over, I think thats best for the moment. Toshi is still on tantivy v0.10, but toshi-types was simple enough to port. That's another fork depencency for the moment, but that won't be needed anymore as soon as toshi moves to tantivy 0.11.
