### PR TITLE
Update dependencies and improve error handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,19 +11,19 @@ jobs:
       DEBUG: "*"
     strategy:
       matrix:
-        os: [ubuntu-16.04, macOS-latest, windows-latest]
+        os: [ubuntu-20.04, macOS-latest, windows-latest]
         arch: [x86_64]
         include:
-          - os: ubuntu-16.04
-            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-20.04
+            target: x86_64-unknown-linux-musl
             cross: false
-          - os: ubuntu-16.04
+          - os: ubuntu-20.04
             arch: armv7
-            target: armv7-unknown-linux-gnueabihf
+            target: armv7-unknown-linux-musl
             cross: true
-          - os: ubuntu-16.04
+          - os: ubuntu-20.04
             arch: aarch64
-            target: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-musl
             cross: true
           - os: macOS-latest
             target: x86_64-apple-darwin
@@ -50,7 +50,7 @@ jobs:
       - name: Install NodeJS
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Test (Rust)
@@ -77,7 +77,7 @@ jobs:
           use-cross: ${{ matrix.cross }}
 
       - name: Package (Linux or MacOS)
-        if: matrix.os == 'ubuntu-16.04' || matrix.os == 'macOS-latest'
+        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'macOS-latest'
         env:
           FILENAME: sonar-tantivy-${{ steps.vars.outputs.tag }}-${{ matrix.target }}.tar.gz
         run: |
@@ -103,7 +103,7 @@ jobs:
             *.tar.gz
 
   publish_npm:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     if: startsWith(github.ref, 'refs/tags/v')
     needs: build
     steps:
@@ -113,7 +113,7 @@ jobs:
       - name: Install NodeJS
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Publish (NPM)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
             cross: false
           - os: ubuntu-20.04
             arch: armv7
-            target: armv7-unknown-linux-musl
+            target: armv7-unknown-linux-muslabihf
             cross: true
           - os: ubuntu-20.04
             arch: aarch64
@@ -46,6 +46,7 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}
           override: true
+          default: true
 
       - name: Install NodeJS
         uses: actions/setup-node@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
             cross: false
           - os: ubuntu-20.04
             arch: armv7
-            target: armv7-unknown-linux-muslabihf
+            target: armv7-unknown-linux-musleabihf
             cross: true
           - os: ubuntu-20.04
             arch: aarch64

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ node_modules
 /dist
 *.tar.gz
 *.zip
+yarn.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,14 @@ name = "sonar-tantivy"
 path = "src-rust/main.rs"
 
 [dependencies]
-serde_json = { version = "^1.0", features = ["preserve_order"] }
-serde = { version = "^1.0", features = ["derive"] }
+serde_json = { version = "^1", features = ["preserve_order"] }
+serde = { version = "^1", features = ["derive"] }
 log = "^0.4"
-uuid = "^0.7"
-failure = "^0.1"
-varinteger = "^1.0"
-once_cell = "^0.2"
-
+varinteger = "^1"
+once_cell = "^1"
 toshi-types = { git = "https://github.com/arso-project/Toshi.git", branch = "tantivy018" }
 tantivy = "^0.18"
+anyhow = "^1"
 
 [dev-dependencies]
 tempdir = "^0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,15 +10,18 @@ name = "sonar-tantivy"
 path = "src-rust/main.rs"
 
 [dependencies]
-tantivy = { git = "https://github.com/tantivy-search/tantivy.git", rev = "7e08e0047bf842d2ce0f9cd7791451bffb85e2f6" }
 serde_json = { version = "^1.0", features = ["preserve_order"] }
 serde = { version = "^1.0", features = ["derive"] }
-toshi-query = { git = "https://github.com/arso-project/Toshi.git", branch = "toshi-query-tantivymaster" }
 log = "^0.4"
 uuid = "^0.7"
 failure = "^0.1"
 varinteger = "^1.0"
 once_cell = "^0.2"
+
+toshi-types = { version = "^0.1", git = "https://github.com/toshi-search/Toshi.git", branch = "master" }
+tantivy = "^0.16"
+# toshi-query = { git = "https://github.com/arso-project/Toshi.git", branch = "toshi-query-tantivymaster" }
+# tantivy = { git = "https://github.com/tantivy-search/tantivy.git", rev = "7e08e0047bf842d2ce0f9cd7791451bffb85e2f6" }
 
 [dev-dependencies]
 tempdir = "^0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,8 @@ failure = "^0.1"
 varinteger = "^1.0"
 once_cell = "^0.2"
 
-toshi-types = { version = "^0.1", git = "https://github.com/toshi-search/Toshi.git", branch = "master" }
-tantivy = "^0.16"
-# toshi-query = { git = "https://github.com/arso-project/Toshi.git", branch = "toshi-query-tantivymaster" }
-# tantivy = { git = "https://github.com/tantivy-search/tantivy.git", rev = "7e08e0047bf842d2ce0f9cd7791451bffb85e2f6" }
+toshi-types = { git = "https://github.com/arso-project/Toshi.git", branch = "tantivy018" }
+tantivy = "^0.18"
 
 [dev-dependencies]
 tempdir = "^0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ serde_json = { version = "^1", features = ["preserve_order"] }
 serde = { version = "^1", features = ["derive"] }
 log = "^0.4"
 varinteger = "^1"
-once_cell = "^1"
+once_cell = "^1.0.1"
 toshi-types = { git = "https://github.com/arso-project/Toshi.git", branch = "tantivy018" }
 tantivy = "^0.18"
 anyhow = "^1"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 ```
 cargo test
-CARGO_ENV=development npm run test
+RUST_ENV=development npm run test
 ```
 
 ## Making a release

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "Franz Heinzmann",
   "license": "MIT",
   "dependencies": {
+    "ansi-colors": "^4.1.3",
     "debug": "^4.1.1",
     "duplexify": "^4.1.1",
     "pump": "^3.0.0",

--- a/src-nodejs/catalog.js
+++ b/src-nodejs/catalog.js
@@ -7,7 +7,6 @@ const SEGMENT_FILES = [
   '.fieldnorm',
   '.idx',
   '.pos',
-  '.posidx',
   '.store',
   '.term'
 ]

--- a/src-nodejs/index.js
+++ b/src-nodejs/index.js
@@ -17,6 +17,9 @@ function getCommandAndArgs () {
       '--color=always'
     ]
     if (process.env.RUST_BUILD === 'release') args.push('--release')
+    if (process.env.CARGO_ARGS) {
+      args.push(...process.env.CARGO_ARGS.split(' '))
+    }
     args.push('--')
     return ['cargo', args]
   } else {

--- a/src-nodejs/index.js
+++ b/src-nodejs/index.js
@@ -9,19 +9,26 @@ const CARGO_TOML = p.resolve(p.join(__dirname, '../Cargo.toml'))
 module.exports = openSonar
 module.exports.segmentFiles = Sonar.segmentFiles
 
-function getCommand () {
+function getCommandAndArgs () {
   if (process.env.RUST_ENV === 'development') {
-    const release = process.env.RUST_BUILD === 'release' ? '--release ' : ''
-    return `cargo run --manifest-path=${CARGO_TOML} ${release} --color=always -- `
+    const args = [
+      'run',
+      `--manifest-path=${CARGO_TOML}`,
+      '--color=always'
+    ]
+    if (process.env.RUST_BUILD === 'release') args.push('--release')
+    args.push('--')
+    return ['cargo', args]
   } else {
-    return COMMAND_PATH
+    return [COMMAND_PATH, []]
   }
 }
 
 function openSonar (path, opts = {}) {
   path = p.resolve(path)
-  const command = getCommand()
-  const pipe = new Pipe(command, [path], {
+  const [command, args] = getCommandAndArgs()
+  args.push(path)
+  const pipe = new Pipe(command, args, {
     log: opts.log || (process.env.RUST_ENV === 'development' && console.log)
   })
   opts.path = path

--- a/src-rust/handles.rs
+++ b/src-rust/handles.rs
@@ -1,6 +1,6 @@
 use crate::index::{IndexCatalog, SegmentInfo};
 use crate::rpc::Request;
-use failure::Error;
+use anyhow::Error;
 use serde::{Deserialize, Serialize};
 use serde_json;
 use std::fmt;

--- a/src-rust/index.rs
+++ b/src-rust/index.rs
@@ -229,7 +229,7 @@ impl IndexHandle {
         if self.query_parser.is_none() {
             let mut fields = vec![];
             let all_fields = schema.fields();
-            for field_entry in all_fields {
+            for (field, field_entry) in all_fields {
                 if !field_entry.is_indexed() {
                     break;
                 }
@@ -308,6 +308,7 @@ impl IndexHandle {
                 schema,
                 opstamp,
                 payload: None,
+                index_settings: tantivy::IndexSettings::default(),
             };
             save_metas(&metas, self.index.directory_mut())?;
         } else {
@@ -383,20 +384,19 @@ fn move_segment() {
     // get the segment_id for the segment in index1 and copy the files in index2 dir
     let moving_segment = allsegments.pop().unwrap();
     let uuid_string = moving_segment.uuid_string();
-    let exts = [
-        ".fast",
-        ".fieldnorm",
-        ".idx",
-        ".pos",
-        ".posidx",
-        ".store",
-        ".term",
-    ];
+    // let mut p = base_path.clone();
+    // p.push(["testindex1/"].concat());
+    // let e = fs::read_dir(&p).unwrap();
+    // for x in e {
+    //     eprintln!("PATH {:?}", x);
+    // }
+    let exts = [".fast", ".fieldnorm", ".idx", ".pos", ".store", ".term"];
     for ext in exts.iter() {
         let mut path1 = base_path.clone();
         path1.push(["testindex1/", &uuid_string, ext].concat());
         let mut path2 = base_path.clone();
         path2.push(["testindex2/", &uuid_string, ext].concat());
+        // fs::create_dir_all(path2.parent().unwrap()).unwrap();
         let _result = fs::copy(path1, path2).unwrap();
     }
 

--- a/src-rust/index.rs
+++ b/src-rust/index.rs
@@ -174,7 +174,7 @@ impl IndexHandle {
                 let mut document = Document::default();
                 for (field_name, value) in doc {
                     match schema.get_field(&field_name) {
-                        Some(field) => document.add(FieldValue::new(field, value.clone())),
+                        Some(field) => document.add_field_value(field, value.clone()),
                         None => eprintln!("Invalid field: {}", field_name),
                     }
                 }
@@ -229,7 +229,7 @@ impl IndexHandle {
         if self.query_parser.is_none() {
             let mut fields = vec![];
             let all_fields = schema.fields();
-            for (field, field_entry) in all_fields {
+            for (_field, field_entry) in all_fields {
                 if !field_entry.is_indexed() {
                     break;
                 }

--- a/src-rust/main.rs
+++ b/src-rust/main.rs
@@ -1,4 +1,3 @@
-extern crate failure;
 use crate::index::IndexCatalog;
 use rpc::Rpc;
 use std::env;

--- a/src-rust/main.rs
+++ b/src-rust/main.rs
@@ -20,6 +20,7 @@ mod handles;
 mod index;
 mod query;
 mod rpc;
+mod search;
 
 fn main() -> io::Result<()> {
     let args: Vec<String> = env::args().collect();

--- a/src-rust/query.rs
+++ b/src-rust/query.rs
@@ -2,7 +2,6 @@ use crate::handles::Res;
 use crate::index::IndexCatalog;
 use crate::rpc::Request;
 use crate::search::search_index;
-use failure::Error;
 use serde::Deserialize;
 use toshi_types::Search;
 
@@ -12,7 +11,7 @@ struct QueryRequest {
     search: Search,
 }
 
-pub fn query_json(catalog: &mut IndexCatalog, request: &Request) -> Result<Res, Error> {
+pub fn query_json(catalog: &mut IndexCatalog, request: &Request) -> Result<Res, anyhow::Error> {
     let request: QueryRequest = request.message()?;
     let handle = catalog.get_index(&request.index)?;
     let reader = handle.get_reader()?;

--- a/src-rust/query.rs
+++ b/src-rust/query.rs
@@ -1,10 +1,10 @@
 use crate::handles::Res;
 use crate::index::IndexCatalog;
 use crate::rpc::Request;
+use crate::search::search_index;
 use failure::Error;
 use serde::Deserialize;
-use toshi_query::search::search_index;
-use toshi_query::Search;
+use toshi_types::Search;
 
 #[derive(Deserialize)]
 struct QueryRequest {
@@ -14,13 +14,10 @@ struct QueryRequest {
 
 pub fn query_json(catalog: &mut IndexCatalog, request: &Request) -> Result<Res, Error> {
     let request: QueryRequest = request.message()?;
-    // eprintln!("QUERY {:?}", req);
     let handle = catalog.get_index(&request.index)?;
-    // let tantivy_results = handle.query(&req.query, req.limit.unwrap_or(10), req.snippet_field)?;
     let reader = handle.get_reader()?;
-    let searcher = reader.searcher();
 
-    let results = search_index(&handle.index, &searcher, request.search);
+    let results = search_index(&handle.index, &reader, request.search);
     match results {
         Ok(results) => {
             // let value: Value = Value::from(results);

--- a/src-rust/search.rs
+++ b/src-rust/search.rs
@@ -1,11 +1,8 @@
 use log::*;
 use tantivy::collector::{FacetCollector, MultiCollector, TopDocs};
-use tantivy::directory::MmapDirectory;
-use tantivy::merge_policy::MergePolicy;
 use tantivy::query::{AllQuery, QueryParser};
 use tantivy::schema::*;
-use tantivy::space_usage::SearcherSpaceUsage;
-use tantivy::{Document, Index, IndexReader, IndexWriter, ReloadPolicy, Term};
+use tantivy::{Index, IndexReader};
 use toshi_types::{CreateQuery, Error, FlatNamedDocument, KeyValue, Query, ScoredDoc, Search};
 
 pub type SearchResults = toshi_types::SearchResults<FlatNamedDocument>;

--- a/src-rust/search.rs
+++ b/src-rust/search.rs
@@ -1,0 +1,106 @@
+use log::*;
+use tantivy::collector::{FacetCollector, MultiCollector, TopDocs};
+use tantivy::directory::MmapDirectory;
+use tantivy::merge_policy::MergePolicy;
+use tantivy::query::{AllQuery, QueryParser};
+use tantivy::schema::*;
+use tantivy::space_usage::SearcherSpaceUsage;
+use tantivy::{Document, Index, IndexReader, IndexWriter, ReloadPolicy, Term};
+use toshi_types::{CreateQuery, Error, FlatNamedDocument, KeyValue, Query, ScoredDoc, Search};
+
+pub type SearchResults = toshi_types::SearchResults<FlatNamedDocument>;
+
+pub fn search_index(
+    index: &Index,
+    reader: &IndexReader,
+    search: Search,
+) -> Result<SearchResults, Error> {
+    let searcher = reader.searcher();
+    let schema = index.schema();
+    let mut multi_collector = MultiCollector::new();
+
+    let sorted_top_handle = search.sort_by.clone().and_then(|sort_by| {
+        info!("Sorting with: {}", sort_by);
+        if let Some(f) = schema.get_field(&sort_by) {
+            let entry = schema.get_field_entry(f);
+            if entry.is_fast() && entry.is_stored() {
+                let c = TopDocs::with_limit(search.limit).order_by_u64_field(f);
+                return Some(multi_collector.add_collector(c));
+            }
+        }
+        None
+    });
+
+    let top_handle = multi_collector.add_collector(TopDocs::with_limit(search.limit));
+    let facet_handle = search.facets.clone().and_then(|f| {
+        if let Some(field) = schema.get_field(f.get_facets_fields()) {
+            let mut col = FacetCollector::for_field(field);
+            for term in f.get_facets_values() {
+                col.add_facet(&term);
+            }
+            Some(multi_collector.add_collector(col))
+        } else {
+            None
+        }
+    });
+
+    if let Some(query) = search.query {
+        let gen_query = match query {
+            Query::Regex(regex) => regex.create_query(&schema)?,
+            Query::Phrase(phrase) => phrase.create_query(&schema)?,
+            Query::Fuzzy(fuzzy) => fuzzy.create_query(&schema)?,
+            Query::Exact(term) => term.create_query(&schema)?,
+            Query::Range(range) => range.create_query(&schema)?,
+            Query::Boolean { bool } => bool.create_query(&schema)?,
+            Query::Raw { raw } => {
+                let fields: Vec<Field> = schema
+                    .fields()
+                    .filter_map(|f| schema.get_field(f.1.name()))
+                    .collect();
+                let query_parser = QueryParser::for_index(&index, fields);
+                query_parser.parse_query(&raw)?
+            }
+            Query::All => Box::new(AllQuery),
+        };
+
+        trace!("{:?}", gen_query);
+        let mut scored_docs = searcher.search(&*gen_query, &multi_collector)?;
+
+        // FruitHandle isn't a public type which leads to some duplicate code like this.
+        let docs: Vec<ScoredDoc<FlatNamedDocument>> = if let Some(h) = sorted_top_handle {
+            h.extract(&mut scored_docs)
+                .into_iter()
+                .map(|(score, doc)| {
+                    let d = searcher.doc(doc).expect("Doc not found in segment");
+                    ScoredDoc::<FlatNamedDocument>::new(
+                        Some(score as f32),
+                        schema.to_named_doc(&d).into(),
+                    )
+                })
+                .collect()
+        } else {
+            top_handle
+                .extract(&mut scored_docs)
+                .into_iter()
+                .map(|(score, doc)| {
+                    let d = searcher.doc(doc).expect("Doc not found in segment");
+                    ScoredDoc::<FlatNamedDocument>::new(Some(score), schema.to_named_doc(&d).into())
+                })
+                .collect()
+        };
+
+        if let Some(facets) = facet_handle {
+            if let Some(t) = &search.facets {
+                let facet_counts = facets
+                    .extract(&mut scored_docs)
+                    .get(&t.get_facets_values()[0])
+                    .map(|(f, c)| KeyValue::new(f.to_string(), c))
+                    .collect();
+                return Ok(SearchResults::with_facets(docs, facet_counts));
+            }
+        }
+        Ok(SearchResults::new(docs))
+    } else {
+        Err(Error::QueryError("Empty Query Provided".into()))
+    }
+}


### PR DESCRIPTION
This PR does a few things:

* Update tantivy to latest 0.18
* Update toshi-types to latest
* Replace failure with anyhow
* Update other minor dependencies
* Improve error handling on Node.js side to print a helpful message when sonar-tantivy crashed or couldn't be started
* Update github actions CI workflow
* Build releases with musl to not have to worry about using an old-enough libc